### PR TITLE
increment build number for 3.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,8 @@ requirements:
     - poetry-core >=1.0.0
   run:
     - python
-    - typing_extensions >=4.4  # [py<310]
+    - typing-extensions >=4.7.1  # [py<38]
+    - typing-extensions >=4.9    # [py>=38]
 
 test:
   imports:
@@ -30,8 +31,9 @@ test:
   source_files:
     - tests
   requires:
-    - pytest >=6.2,<7
-    - pytest-benchmark >=3.4,<=4.0.0
+    - pytest >=7.4,<8.1  # [py<38]
+    - pytest >=8.1       # [py>=38]
+    - pytest-benchmark >=4.0.0
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   skip: True  # [py<37]
-  number: 0
+  number: 1
   script:
     - python -c '__import__("os").unlink("pyproject.toml")'
     - {{ PYTHON }} -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ test:
     - tests
   requires:
     - pytest >=6.2,<7
-    - pytest-benchmark >=3.4,<4
+    - pytest-benchmark >=3.4,<=4.0.0
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ build:
   skip: True  # [py<37]
   number: 1
   script:
-    - python -c '__import__("os").unlink("pyproject.toml")'
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - pip
     - wheel
-    - poetry-core >=1.0.0
+    - poetry_core >=1,<2
   run:
     - python
     - typing-extensions >=4.7.1  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - pip
     - wheel
+    - poetry-core >=1.0.0
   run:
     - python
     - typing_extensions >=4.4  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   host:
     - python
     - pip
-    - wheel
     - poetry_core >=1,<2
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - poetry_core >=1,<2
+    - poetry-core >=1,<2
   run:
     - python
     - typing-extensions >=4.7.1  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,7 @@ test:
   source_files:
     - tests
   requires:
-    - pytest >=7.4,<8.1  # [py<38]
-    - pytest >=8.1       # [py>=38]
+    - pytest >=7.4,<8.1 
     - pytest-benchmark >=4.0.0
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
   run:
     - python
     - typing-extensions >=4.7.1  # [py<38]
-    - typing-extensions >=4.9    # [py>=38]
 
 test:
   imports:
@@ -30,8 +29,8 @@ test:
   source_files:
     - tests
   requires:
-    - pytest >=7.4,<8.1 
-    - pytest-benchmark >=4.0.0
+    - pytest >=6.2,<7
+    - pytest-benchmark >=3.4,<4
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,14 +13,13 @@ build:
   number: 1
   script:
     - python -c '__import__("os").unlink("pyproject.toml")'
-    - {{ PYTHON }} -m pip install . -vv
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
     - wheel
-    - poetry
   run:
     - python
     - typing_extensions >=4.4  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - poetry-core >=1,<2
   run:
     - python
-    - typing-extensions >=4.7.1  # [py<38]
+    - typing_extensions >=4.7.1  # [py<38]
 
 test:
   imports:


### PR DESCRIPTION
graphql-core 3.2.3

**Destination channel:** defaults

### Links

- [PKG-4483](https://anaconda.atlassian.net/browse/PKG-4483) 
- [Upstream repository](https://github.com/graphql-python/graphql-core)
- [Upstream changelog/diff](https://github.com/graphql-python/graphql-core/releases/tag/v3.2.3)
- Relevant dependency PRs:
  - moto (for 3.12 build only) 

### Explanation of changes:

- ...


[PKG-4483]: https://anaconda.atlassian.net/browse/PKG-4483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ