### PR TITLE
graphql-core 3.2.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
 channels:
-- https://staging.continuum.io/prefect/fs/pytest-benchmark-feedstock/pr6/41a08f5
+- https://staging.continuum.io/prefect/fs/graphql-core-feedstock/pr6/fd2b2fc

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-channels:
-- https://staging.continuum.io/prefect/fs/graphql-core-feedstock/pr6/fd2b2fc

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
+channels:
+- https://staging.continuum.io/prefect/fs/pytest-benchmark-feedstock/pr6/41a08f5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,17 @@
+{% set name = "graphql-core" %}
 {% set version = "3.2.3" %}
 
 package:
-  name: graphql-core
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/g/graphql-core/graphql-core-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/graphql-core/graphql-core-{{ version }}.tar.gz
   sha256: 06d2aad0ac723e35b1cb47885d3e5c45e956a53bc1b209a9fc5369007fe46676
 
 build:
   skip: True  # [py<37]
-  number: 1
+  number: 2
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -29,8 +30,9 @@ test:
   source_files:
     - tests
   requires:
-    - pytest >=6.2,<7
-    - pytest-benchmark >=3.4,<4
+    - pytest >=6.2
+    - pytest-benchmark >=5.1, <6  # [py>=39]
+    - pytest-benchmark >=4.0, <5  # [py<39]
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
   source_files:
     - tests
   requires:
-    - pytest >=6.2
+    - pytest >=6.2,<9
     - pytest-benchmark >=3.4,<6
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "graphql-core" %}
-{% set version = "3.2.3" %}
+{% set version = "3.2.6" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/graphql-core/graphql-core-{{ version }}.tar.gz
-  sha256: 06d2aad0ac723e35b1cb47885d3e5c45e956a53bc1b209a9fc5369007fe46676
+  url: https://pypi.org/packages/source/g/graphql-core/graphql_core-{{ version }}.tar.gz
+  sha256: c08eec22f9e40f0bd61d805907e3b3b1b9a320bc606e23dc145eebca07c8fbab
 
 build:
   skip: True  # [py<37]
-  number: 2
+  number: 0
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -22,7 +22,7 @@ requirements:
     - poetry-core >=1,<2
   run:
     - python
-    - typing_extensions >=4.7.1  # [py<38]
+    - typing_extensions >=4.1,<5  # [py<310]
 
 test:
   imports:
@@ -31,8 +31,7 @@ test:
     - tests
   requires:
     - pytest >=6.2
-    - pytest-benchmark >=5.1, <6  # [py>=39]
-    - pytest-benchmark >=4.0, <5  # [py<39]
+    - pytest-benchmark >=3.4,<6
     - pip
   commands:
     - pip check


### PR DESCRIPTION
graphql-core 3.2.6

**Destination channel:** Defaults

### Links

- [PKG-7380]
- dev_url:        https://github.com/graphql-python/graphql-core/tree/v3.2.6
- conda_forge:    https://github.com/conda-forge/graphql-core-feedstock
- pypi:           https://pypi.org/project/graphql-core/3.2.6
- pypi inspector: https://inspector.pypi.io/project/graphql-core/3.2.6

### Explanation of changes:

- new version number
- required for: https://github.com/AnacondaRecipes/graphql-relay-feedstock/pull/3


[PKG-7380]: https://anaconda.atlassian.net/browse/PKG-7380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ